### PR TITLE
✨ Add CI for verifying whether the project is CMSIS Compliant

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  schedule:
+    - cron: '0 6 * * 4'
 
 jobs:
   verify-cmsis-compliance:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: Verify CMSIS Compliance
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  verify-cmsis-compliance:
+    name: Verify CMSIS Compliance
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Arm-Examples/verify-cmsis-example-action@latest
+        name: Verify CMSIS Compliance
+        with:
+          branch: ${{ github.ref }}
+          project-file: ./Blinky.csolution.yml
+          API_TOKEN: ${{ secrets.CMSIS_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Blinky project for Arm FVP/AVH
+[![CMSIS Compliance](https://img.shields.io/github/actions/workflow/status/Arm-Examples/Blinky_AVH_uV/ci.yml?logo=arm&logoColor=0091bd&label=CMSIS%20Compliance)](https://www.keil.arm.com/cmsis)
 
 The **Blinky** project can be used to verify the basic tool setup. It is compliant to the [Cortex Microcontroller Software Interface Standard (CMSIS)](https://arm-software.github.io/CMSIS_5/General/html/index.html).
 


### PR DESCRIPTION
Introduce a CI flow to verify the project is compliant with CMSIS and hence, could be used with the CMSIS toolbox